### PR TITLE
Handle breaking change from graphql-engine 2.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Weaviate Data Connector
 
+> [!NOTE]
+> If using this connector with `graphql-engine` <= v2.32 use the [v2.23.0]() tag from this branch. If using this connector with `graphql-engine` >= v2.33 use main. There was a breaking change this is not backwards compatiple in the query request IR.
+
 This repository contains the source code for a prototype [data connector agent](https://github.com/hasura/graphql-engine/blob/master/dc-agents/README.md) for Weaviate to be able to use it with Hasura.
 
 This repository also contains a Dockerfile to be able to build an image in your own architecture and contains a docker-compose.yaml to try out the connector with Hasura.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Weaviate Data Connector
 
 > [!NOTE]
-> If using this connector with `graphql-engine` <= v2.32 use the [v2.23.0](https://github.com/hasura/weaviate_gdc/tree/v2.32.0) tag from this branch. If using this connector with `graphql-engine` >= v2.33 use main. There was a breaking change this is not backwards compatiple in the query request IR.
+> If using this connector with `graphql-engine` <= v2.32 use the [v2.32.0](https://github.com/hasura/weaviate_gdc/tree/v2.32.0) tag from this branch. If using this connector with `graphql-engine` >= v2.33 use main. There was a breaking change this is not backwards compatiple in the query request IR.
 
 This repository contains the source code for a prototype [data connector agent](https://github.com/hasura/graphql-engine/blob/master/dc-agents/README.md) for Weaviate to be able to use it with Hasura.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Weaviate Data Connector
 
 > [!NOTE]
-> If using this connector with `graphql-engine` <= v2.32 use the [v2.23.0]() tag from this branch. If using this connector with `graphql-engine` >= v2.33 use main. There was a breaking change this is not backwards compatiple in the query request IR.
+> If using this connector with `graphql-engine` <= v2.32 use the [v2.23.0](https://github.com/hasura/weaviate_gdc/tree/v2.32.0) tag from this branch. If using this connector with `graphql-engine` >= v2.33 use main. There was a breaking change this is not backwards compatiple in the query request IR.
 
 This repository contains the source code for a prototype [data connector agent](https://github.com/hasura/graphql-engine/blob/master/dc-agents/README.md) for Weaviate to be able to use it with Hasura.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^8.1.0",
-        "@hasura/dc-api-types": "0.32.0",
+        "@hasura/dc-api-types": "0.41.0",
         "fastify": "^4.13.0",
         "mathjs": "^11.0.0",
         "pino-pretty": "^8.0.0",
-        "weaviate-client": "^2.14.5",
         "weaviate-ts-client": "^1.3.2",
         "xml2js": "github:Leonidas-from-XIV/node-xml2js"
       },
@@ -95,8 +94,9 @@
       }
     },
     "node_modules/@hasura/dc-api-types": {
-      "version": "0.32.0",
-      "license": "Apache-2.0"
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@hasura/dc-api-types/-/dc-api-types-0.41.0.tgz",
+      "integrity": "sha512-pCUqvJdSP+F91kEwEt8hsTDFauEfm4Y8p83Ab9SqrRAH2KFQsHMT7uqX20iXeeP8DwwPOjCpna5xM86oCyaGtg=="
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
@@ -1292,16 +1292,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "node_modules/weaviate-client": {
-      "version": "2.14.5",
-      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-2.14.5.tgz",
-      "integrity": "sha512-pGC1AAYAyBF8Gl8D45AE9JOmvyP4cMHC+TeF6New4ISEq/RefxtZH7F5A26FLHx+3aLGTBGXJhziB6r9x6dyVQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "graphql-request": "^5.1.0",
-        "isomorphic-fetch": "^3.0.0"
-      }
     },
     "node_modules/weaviate-ts-client": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^8.1.0",
-    "@hasura/dc-api-types": "0.32.0",
+    "@hasura/dc-api-types": "0.41.0",
     "fastify": "^4.13.0",
     "mathjs": "^11.0.0",
     "pino-pretty": "^8.0.0",

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -1,4 +1,5 @@
 import {
+  ComparisonColumn,
   ComparisonValue,
   Expression,
   Field,
@@ -12,7 +13,14 @@ import { Config } from "../config";
 import { WhereFilter } from "weaviate-ts-client";
 import { getWeaviateClient } from "../weaviate";
 import { builtInPropertiesKeys } from "./schema";
-import { e } from "mathjs";
+
+function column_name(column: ComparisonColumn): string {
+  if (Array.isArray(column.name)) {
+    return column.name.join(".");
+  } else {
+    return column.name;
+  }
+}
 
 export async function executeQuery(
   query: QueryRequest,
@@ -305,31 +313,31 @@ export function queryWhereOperator(
         case "equal":
           return {
             operator: "Equal",
-            path: [...path, expression.column.name[0]],
+            path: [...path, column_name(expression.column)],
             ...expressionValue(expression.value),
           };
         case "less_than":
           return {
             operator: "LessThan",
-            path: [...path, expression.column.name[0]],
+            path: [...path, column_name(expression.column)],
             ...expressionValue(expression.value),
           };
         case "less_than_or_equal":
           return {
             operator: "LessThanEqual",
-            path: [...path, expression.column.name[0]],
+            path: [...path, column_name(expression.column)],
             ...expressionValue(expression.value),
           };
         case "greater_than":
           return {
             operator: "GreaterThan",
-            path: [...path, expression.column.name[0]],
+            path: [...path, column_name(expression.column)],
             ...expressionValue(expression.value),
           };
         case "greater_than_or_equal":
           return {
             operator: "GreaterThanEqual",
-            path: [...path, expression.column.name[0]],
+            path: [...path, column_name(expression.column)],
             ...expressionValue(expression.value),
           };
         case "near_text":
@@ -345,7 +353,7 @@ export function queryWhereOperator(
         case "is_null":
           return {
             operator: "IsNull",
-            path: [...path, expression.column.name[0]],
+            path: [...path, column_name(expression.column)],
           };
         default:
           throw new Error(
@@ -360,7 +368,7 @@ export function queryWhereOperator(
             operator: "Or",
             operands: expression.values.map((value) => ({
               operator: "Equal",
-              path: [...path, expression.column.name[0]],
+              path: [...path, column_name(expression.column)],
               [expressionValueType(expression.value_type)]: value,
             })),
           };


### PR DESCRIPTION
There was a breaking change in `graphql-engine`'s latest release version 2.33. This updates the `dc-api-types` and accounts for the changes to update for 2.33.